### PR TITLE
Add beautiful-soup to run requirements.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - matplotlib
     - pillow
     - sphinx
+    - beautifulsoup4
 
 test:
   imports:


### PR DESCRIPTION
This requirement seems to be missing when I used "conda install sphinx-gallery".

Unless I misunderstood something ?

It also seems to be absent from https://github.com/sphinx-gallery/sphinx-gallery/blob/master/requirements.txt.
You might consider that it needs fixing there *first* ?